### PR TITLE
Update deployment target from burr to azul.cdzombak.net

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
         run: |
-          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.cdzombak.net/clock.dzdz.cz/
+          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.tailnet-003a.ts.net/clock.dzdz.cz/
 
   ntfy:
     name: Ntfy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           RSYNC_PASSWORD: ${{ secrets.RSYNC_PASSWORD }}
         run: |
-          rsync -avz --delete ./www/ rsync://wwwdeploy@burr.tailnet-003a.ts.net/clock.dzdz.cz/
+          rsync -avz --delete ./www/ rsync://wwwdeploy@azul.cdzombak.net/clock.dzdz.cz/
 
   ntfy:
     name: Ntfy


### PR DESCRIPTION
# Update deployment target from burr to azul.cdzombak.net

## Summary
Updates the rsync deployment target hostname from `burr.tailnet-003a.ts.net` to `azul.cdzombak.net`. This changes which server receives the deployed site files when the GitHub Actions workflow runs.

## Review & Testing Checklist for Human
- [ ] Verify `azul.cdzombak.net` is accessible from GitHub Actions runners and properly configured to receive rsync deployments at the `/clock.dzdz.cz/` module path
- [ ] Confirm the `RSYNC_PASSWORD` secret works with azul (credentials may need to be rotated if azul uses different credentials than burr)
- [ ] After merging, trigger a deployment (push to main) and verify files are correctly deployed to azul and the site works as expected
- [ ] Verify the destination path structure on azul matches what was on burr

### Notes
This is part of a migration from burr to azul across multiple repositories. The change is a single-line hostname update in the deployment workflow.

Link to Devin run: https://app.devin.ai/sessions/77c390486c6e4c368a9f2e486d472c0e
Requested by: Chris Dzombak (chris@dzombak.com) / @cdzombak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment target used by the build-and-deploy process.
  * This change aims to improve service stability and operational reliability during deployments while keeping deployment behavior and options unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->